### PR TITLE
chore: replace ts-node with @oxc-node/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@microsoft/api-extractor": "^7.58.1",
         "@ota-meshi/eslint-plugin": "^0.20.0",
         "@ota-meshi/test-snapshot": "^1.0.0",
+        "@oxc-node/core": "^0.1.0",
         "@svitejs/changesets-changelog-github-compact": "^1.1.0",
         "@types/estree": "^1.0.0",
         "@types/mocha": "^10.0.0",
@@ -48,7 +49,6 @@
         "prettier": "^3.0.0",
         "pretty-format": "^30.0.0",
         "rimraf": "^6.0.0",
-        "ts-node": "^10.9.2",
         "tsdown": "^0.21.7",
         "typescript": "~6.0.0",
         "typescript-eslint": "^8.56.0"
@@ -644,28 +644,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1566,6 +1544,322 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@oxc-node/core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core/-/core-0.1.0.tgz",
+      "integrity": "sha512-Spk/ey3zg1CpBU1eUHBPbAbfFddntutZPPsweh+kNh9M9Ksc8j9OCujralW9HrVyi6nNWek1PnMfSZ7NPLLCKA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Brooooooklyn"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Boshen"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pirates": "^4.0.7"
+      },
+      "optionalDependencies": {
+        "@oxc-node/core-android-arm-eabi": "0.1.0",
+        "@oxc-node/core-android-arm64": "0.1.0",
+        "@oxc-node/core-darwin-arm64": "0.1.0",
+        "@oxc-node/core-darwin-x64": "0.1.0",
+        "@oxc-node/core-freebsd-x64": "0.1.0",
+        "@oxc-node/core-linux-arm-gnueabihf": "0.1.0",
+        "@oxc-node/core-linux-arm64-gnu": "0.1.0",
+        "@oxc-node/core-linux-arm64-musl": "0.1.0",
+        "@oxc-node/core-linux-ppc64-gnu": "0.1.0",
+        "@oxc-node/core-linux-s390x-gnu": "0.1.0",
+        "@oxc-node/core-linux-x64-gnu": "0.1.0",
+        "@oxc-node/core-linux-x64-musl": "0.1.0",
+        "@oxc-node/core-openharmony-arm64": "0.1.0",
+        "@oxc-node/core-wasm32-wasi": "0.1.0",
+        "@oxc-node/core-win32-arm64-msvc": "0.1.0",
+        "@oxc-node/core-win32-ia32-msvc": "0.1.0",
+        "@oxc-node/core-win32-x64-msvc": "0.1.0"
+      }
+    },
+    "node_modules/@oxc-node/core-android-arm-eabi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-android-arm-eabi/-/core-android-arm-eabi-0.1.0.tgz",
+      "integrity": "sha512-+ycNqMBKBz3EWpQKm7HgUMRLGKfFZsZ/JxN9ctx12CwGy0PTtjX3TB+1WEbiJrgWiZM0axBjuwe4MEqS6j1kgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-node/core-android-arm64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-android-arm64/-/core-android-arm64-0.1.0.tgz",
+      "integrity": "sha512-sJZGDgQwlawrGnLPu1ueAoM/0sUKtCUZr0y4IljarPCVbVBHimcxKcyNlzucIjyQwwiptZourCbUNHONvm4i1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-node/core-darwin-arm64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-darwin-arm64/-/core-darwin-arm64-0.1.0.tgz",
+      "integrity": "sha512-6hsKxbYCzAg390Y/URpCCDPDM4HSHl+Cxodsh2lw6GjX68FDFgLbEwOU2ivXfnXEmJMEMLSjv/0tPTBzDPIJJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-node/core-darwin-x64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-darwin-x64/-/core-darwin-x64-0.1.0.tgz",
+      "integrity": "sha512-VCygvTqrquI3u25B0D6LjO1GnAVMyuAXae4PxRwmEwNuWgWaErG3zHaaU6+hBlXysiyZWKhSXAoAAJmrwe17tA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-node/core-freebsd-x64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-freebsd-x64/-/core-freebsd-x64-0.1.0.tgz",
+      "integrity": "sha512-UQ0hCpwTOUpg1Oh/H/I0BRQmt8XCjCQArk3Cp0P1qc3/xcZ2IcTihxwIZAKLr/lkl+7Ya5rBn9zuY1fe28HaqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-node/core-linux-arm-gnueabihf": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-0.1.0.tgz",
+      "integrity": "sha512-Z+Il9u39MIhusioOQyRfZFMRY+e6QtePxRH44bUHXj7r+eTcHXTJyaDqqCr1HRvtPc9K/re1zH2hV9yEZtHUsg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-node/core-linux-arm64-gnu": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-linux-arm64-gnu/-/core-linux-arm64-gnu-0.1.0.tgz",
+      "integrity": "sha512-nt2IT6MCZApyWsaEjky2znYZIII/BphuqD5mtnbGrFeF3dBpO6U2JiXHCQK/FZ/yrVLlCmcPgcOEL6yMYu8Tiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-node/core-linux-arm64-musl": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-linux-arm64-musl/-/core-linux-arm64-musl-0.1.0.tgz",
+      "integrity": "sha512-0CYLp49qV4KIZmgckqiNcHiLROcb9J1sQSejIKJwbgcaoBLRw5olRCUE9cOi424jRxzXq50zsEv4ihheSA71pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-node/core-linux-ppc64-gnu": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-0.1.0.tgz",
+      "integrity": "sha512-eRarcfNvV0NorkUx5oywdUlC+E35dQCwZzI9BRe6ePywyeCBGJw6D5NnMdPfhCI1olPTkpPdCHXjY/gcl8XH3Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-node/core-linux-s390x-gnu": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-linux-s390x-gnu/-/core-linux-s390x-gnu-0.1.0.tgz",
+      "integrity": "sha512-PZx57NdmM9jq5jWXV1uk/PfHuDbodQ71KIwkNtLqLTdgJZS69m9Xi9j0vo6yyMBGJMD+aYK79eO0KxPU/5TgSA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-node/core-linux-x64-gnu": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-linux-x64-gnu/-/core-linux-x64-gnu-0.1.0.tgz",
+      "integrity": "sha512-N9lTK2chPpsXx0Ur6nUTW7OFE0d0wK4qpbb7WJAyJ48mU9bC22xuCi2yGDB748n16Yly3+mCJ+LiU7r3aBLZhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-node/core-linux-x64-musl": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-linux-x64-musl/-/core-linux-x64-musl-0.1.0.tgz",
+      "integrity": "sha512-xs/ObZhHfN6AcAcjYQQkaeXBR1khm7ZlF6uOpmEhdAiG80P1aVw9ndEYz0LQHp2iVhPaRL9UfYuVKLqKah1TAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-node/core-openharmony-arm64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-openharmony-arm64/-/core-openharmony-arm64-0.1.0.tgz",
+      "integrity": "sha512-B7ixIkc5G7pIqZmWM8oqi/qDdcRdo//mTNM4ChFNU1oou2Hy/FlidAKppMLFVRc4ddRrp6uEvYrT1LgZnjzn6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-node/core-wasm32-wasi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-wasm32-wasi/-/core-wasm32-wasi-0.1.0.tgz",
+      "integrity": "sha512-W4jM3S4XRgtpCKDGNGitCCfinIlyRAKoiQHi1nM+Nul3+Xf2RZqFOgBzdHxT+CahrT8kDi+p7gDGQN3uziwM1A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.1",
+        "@emnapi/runtime": "1.9.1",
+        "@napi-rs/wasm-runtime": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-node/core-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-node/core-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-node/core-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-node/core-win32-arm64-msvc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-win32-arm64-msvc/-/core-win32-arm64-msvc-0.1.0.tgz",
+      "integrity": "sha512-3Qi2tdV+JSqK5Cfcpg3FX54zR78dBEFk+/usFXcF+bhMiBy8YmXGd+yDudl+wwEYf9Xz+Hqx74u8YCXrWDAUTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-node/core-win32-ia32-msvc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-win32-ia32-msvc/-/core-win32-ia32-msvc-0.1.0.tgz",
+      "integrity": "sha512-j66qK1qu5FcmfmIYdv1bp7gIuOi1LCDhzFOu7UdWZyFrinZHh7gHnLHngpSibM/M2Zp/mVLLWD2Ojlsy+8VtNA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-node/core-win32-x64-msvc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@oxc-node/core-win32-x64-msvc/-/core-win32-x64-msvc-0.1.0.tgz",
+      "integrity": "sha512-S3qWlUQ7ZrOSLG1IwNiqQEovJU8MZ11Vc9k+NUzNTO20zFPEt9Jq1wFElusxJZBqBsd7AUXIq08n9dXC/ialbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.122.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
@@ -2169,30 +2463,6 @@
         "node": "^14.13.1 || ^16.0.0 || >=18"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2358,16 +2628,6 @@
       "resolved": "https://registry.npmjs.org/@types/natural-compare/-/natural-compare-1.4.3.tgz",
       "integrity": "sha512-XCAxy+Gg6+S6VagwzcknnvCKujj/bVv1q+GFuCrFEelqaZPqJoC+FeXLwc2dp+oLP7qDZQ4ZfQiTJQ9sIUmlLw==",
       "dev": true
-    },
-    "node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -2654,15 +2914,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2784,12 +3035,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -3432,12 +3677,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "node_modules/cross-spawn": {
@@ -6297,12 +6536,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
     "node_modules/map-obj": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -7965,6 +8198,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/pkg-dir": {
@@ -9723,58 +9966,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/tsdown": {
       "version": "0.21.7",
       "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.21.7.tgz",
@@ -10146,13 +10337,6 @@
         "node": ">=20.18.1"
       }
     },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -10291,12 +10475,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -10684,15 +10862,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "update-snap": "npm run update-snap --workspaces --if-present",
     "cover": "npm run cover --workspaces --if-present",
     "preversion": "npm run lint && npm test",
-    "update-visitor": "node --loader=ts-node/esm/transpile-only scripts/update-visitor.mts && eslint src/visitor.mts --fix",
+    "update-visitor": "node --import @oxc-node/core/register scripts/update-visitor.mts && eslint src/visitor.mts --fix",
     "prerelease": "npm run clean && npm run build",
     "release": "changeset publish",
     "postinstall": "npm run build"
@@ -52,6 +52,7 @@
     "@microsoft/api-extractor": "^7.58.1",
     "@ota-meshi/eslint-plugin": "^0.20.0",
     "@ota-meshi/test-snapshot": "^1.0.0",
+    "@oxc-node/core": "^0.1.0",
     "@svitejs/changesets-changelog-github-compact": "^1.1.0",
     "@types/estree": "^1.0.0",
     "@types/mocha": "^10.0.0",
@@ -77,7 +78,6 @@
     "prettier": "^3.0.0",
     "pretty-format": "^30.0.0",
     "rimraf": "^6.0.0",
-    "ts-node": "^10.9.2",
     "tsdown": "^0.21.7",
     "typescript": "~6.0.0",
     "typescript-eslint": "^8.56.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "update-snap": "npm run update-snap --workspaces --if-present",
     "cover": "npm run cover --workspaces --if-present",
     "preversion": "npm run lint && npm test",
-    "update-visitor": "node --import @oxc-node/core/register scripts/update-visitor.mts && eslint src/visitor.mts --fix",
     "prerelease": "npm run clean && npm run build",
     "release": "changeset publish",
     "postinstall": "npm run build"

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -22,11 +22,11 @@
     "build": "npm run bundle",
     "bundle": "tsdown",
     "clean": "rimraf .nyc_output lib coverage",
-    "test": "mocha --loader=ts-node/esm \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
+    "test": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
     "cover": "c8 --reporter=lcov npm run test",
-    "debug": "mocha --loader=ts-node/esm/transpile-only \"tests/src/**/*.mts\" --reporter dot",
+    "debug": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot",
     "type-check": "tsc --noEmit",
-    "update-snap": "mocha --loader=ts-node/esm \"tests/src/**/*.mts\" --reporter dot --update"
+    "update-snap": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --update"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,12 +24,12 @@
     "benchmark:tostring": "node ./scripts/benchmark-tostring.mjs",
     "bundle": "tsdown",
     "clean": "rimraf .nyc_output lib coverage",
-    "test": "mocha --loader=ts-node/esm \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
+    "test": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
     "cover": "c8 --reporter=lcov npm run test",
-    "debug": "mocha --loader=ts-node/esm/transpile-only \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
+    "debug": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
     "type-check": "tsc --noEmit",
-    "update-snap": "mocha --loader=ts-node/esm \"tests/src/**/*.mts\" --reporter dot --update --timeout 60000",
-    "update-pref": " UPDATE_PREF=true mocha --loader=ts-node/esm \"tests/src/performance-snap.mts\" --reporter dot --update --timeout 60000",
+    "update-snap": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --update --timeout 60000",
+    "update-pref": " UPDATE_PREF=true node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/performance-snap.mts\" --reporter dot --update --timeout 60000",
     "update-readme-size": "node ./scripts/gzip-size.mjs"
   },
   "publishConfig": {

--- a/packages/core/tests/src/__snapshots__/manual-test.mts.snap
+++ b/packages/core/tests/src/__snapshots__/manual-test.mts.snap
@@ -2,85 +2,22 @@
 
 exports[`Error tests () => BigNum.valueOf(2).sqrt({ roundingMode: 42 }) 1`] = `[Error: Unknown rounding mode: 42]`;
 
-exports[`standard tests () => 
-        // ((1/3)/2) * ((1/3)/2) * 9 * 4
-        BigNum.valueOf(1)
-            .divide(3)
-            .divide(2)
-            .multiply(BigNum.valueOf(1).divide(3).divide(2))
-            .multiply(9)
-            .multiply(4) 1`] = `"1"`;
-
-exports[`standard tests () => 
-        // (-2) ** (1 / 2)
-        BigNum.valueOf(-2).nthRoot(2) 1`] = `"$NaN$"`;
-
-exports[`standard tests () => 
-        // (1/3 + 1/3 + 1) * 3
-        BigNum.valueOf(1)
-            .divide(3)
-            .add(BigNum.valueOf(1).divide(3))
-            .add(1)
-            .multiply(3) 1`] = `"5"`;
-
-exports[`standard tests () => 
-        // (1/3 + 1/3 - 1) * 3
-        BigNum.valueOf(1)
-            .divide(3)
-            .add(BigNum.valueOf(1).divide(3))
-            .subtract(1)
-            .multiply(3) 1`] = `"-1"`;
-
-exports[`standard tests () => 
-        // 1 / ((1/3)/2) * 9 * 4
-        BigNum.valueOf(1)
-            .divide(BigNum.valueOf(1).divide(3).divide(2))
-            .multiply(9)
-            .multiply(4) 1`] = `"216"`;
-
-exports[`standard tests () => 
-        // 1/3 * (1/3) * 9
-        BigNum.valueOf(1)
-            .divide(3)
-            .multiply(BigNum.valueOf(1).divide(3))
-            .multiply(9) 1`] = `"1"`;
-
-exports[`standard tests () => 
-        // 1/3 / ((1/3)/2) * 9 * 4
-        BigNum.valueOf(1)
-            .divide(3)
-            .divide(BigNum.valueOf(1).divide(3).divide(2))
-            .multiply(9)
-            .multiply(4) 1`] = `"72"`;
-
-exports[`standard tests () => 
-        // 2 ** (1/(1/3))
-        BigNum.valueOf(2).nthRoot(BigNum.valueOf(1).divide(3)) 1`] = `"8"`;
-
-exports[`standard tests () => 
-        // Math.sqrt(-2)
-        BigNum.valueOf(-2).sqrt() 1`] = `"$NaN$"`;
-
-exports[`standard tests () => 
-        // Math.sqrt(2) ** 2
-        BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.round }).pow(2) 1`] = `"\\"1.99999999999999999999522356663907438144\\""`;
+exports[`standard tests () => {
+			// (1/3 + 1/6) * (1/3 + 1/6) * 4
+			const a = BigNum.valueOf(1).divide(3);
+			const b = BigNum.valueOf(1).divide(6);
+			return a.add(b).multiply(a.add(b)).multiply(4);
+		} 1`] = `"1"`;
 
 exports[`standard tests () => {
-            // (1/3 + 1/6) * (1/3 + 1/6) * 4
-            const a = BigNum.valueOf(1).divide(3);
-            const b = BigNum.valueOf(1).divide(6);
-            return a.add(b).multiply(a.add(b)).multiply(4);
-        } 1`] = `"1"`;
-
-exports[`standard tests () => {
-            // (3 ** (1/2))
-            return [
-                BigNum.valueOf(6).nthRoot(2, { roundingMode: RoundingMode.trunc }),
-                BigNum.valueOf(6).nthRoot(2, { roundingMode: RoundingMode.round }),
-                BigNum.valueOf(6).nthRoot(2, { roundingMode: RoundingMode.floor }),
-                BigNum.valueOf(6).nthRoot(2, { roundingMode: RoundingMode.ceil }),
-            ];
-        } 1`] = `
+			// (3 ** (1/2))
+			return [
+				BigNum.valueOf(6).nthRoot(2, { roundingMode: RoundingMode.trunc }),
+				BigNum.valueOf(6).nthRoot(2, { roundingMode: RoundingMode.round }),
+				BigNum.valueOf(6).nthRoot(2, { roundingMode: RoundingMode.floor }),
+				BigNum.valueOf(6).nthRoot(2, { roundingMode: RoundingMode.ceil })
+			];
+		} 1`] = `
 "[
   \\"2.4494897427831780981\\",
   \\"2.4494897427831780982\\",
@@ -90,14 +27,14 @@ exports[`standard tests () => {
 `;
 
 exports[`standard tests () => {
-            // Math.sqrt(2)
-            return [
-                BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.trunc }),
-                BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.round }),
-                BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.floor }),
-                BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.ceil }),
-            ];
-        } 1`] = `
+			// Math.sqrt(2)
+			return [
+				BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.trunc }),
+				BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.round }),
+				BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.floor }),
+				BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.ceil })
+			];
+		} 1`] = `
 "[
   \\"1.4142135623730950488\\",
   \\"1.4142135623730950488\\",
@@ -107,14 +44,14 @@ exports[`standard tests () => {
 `;
 
 exports[`standard tests () => {
-            // Math.sqrt(3)
-            return [
-                BigNum.valueOf(3).sqrt({ roundingMode: RoundingMode.trunc }),
-                BigNum.valueOf(3).sqrt({ roundingMode: RoundingMode.round }),
-                BigNum.valueOf(3).sqrt({ roundingMode: RoundingMode.floor }),
-                BigNum.valueOf(3).sqrt({ roundingMode: RoundingMode.ceil }),
-            ];
-        } 1`] = `
+			// Math.sqrt(3)
+			return [
+				BigNum.valueOf(3).sqrt({ roundingMode: RoundingMode.trunc }),
+				BigNum.valueOf(3).sqrt({ roundingMode: RoundingMode.round }),
+				BigNum.valueOf(3).sqrt({ roundingMode: RoundingMode.floor }),
+				BigNum.valueOf(3).sqrt({ roundingMode: RoundingMode.ceil })
+			];
+		} 1`] = `
 "[
   \\"1.7320508075688772935\\",
   \\"1.7320508075688772935\\",
@@ -124,14 +61,14 @@ exports[`standard tests () => {
 `;
 
 exports[`standard tests () => {
-            // Math.sqrt(5)
-            return [
-                BigNum.valueOf(5).sqrt({ roundingMode: RoundingMode.trunc }),
-                BigNum.valueOf(5).sqrt({ roundingMode: RoundingMode.round }),
-                BigNum.valueOf(5).sqrt({ roundingMode: RoundingMode.floor }),
-                BigNum.valueOf(5).sqrt({ roundingMode: RoundingMode.ceil }),
-            ];
-        } 1`] = `
+			// Math.sqrt(5)
+			return [
+				BigNum.valueOf(5).sqrt({ roundingMode: RoundingMode.trunc }),
+				BigNum.valueOf(5).sqrt({ roundingMode: RoundingMode.round }),
+				BigNum.valueOf(5).sqrt({ roundingMode: RoundingMode.floor }),
+				BigNum.valueOf(5).sqrt({ roundingMode: RoundingMode.ceil })
+			];
+		} 1`] = `
 "[
   \\"2.2360679774997896964\\",
   \\"2.2360679774997896964\\",
@@ -141,14 +78,14 @@ exports[`standard tests () => {
 `;
 
 exports[`standard tests () => {
-            // Math.sqrt(6)
-            return [
-                BigNum.valueOf(6).sqrt({ roundingMode: RoundingMode.trunc }),
-                BigNum.valueOf(6).sqrt({ roundingMode: RoundingMode.round }),
-                BigNum.valueOf(6).sqrt({ roundingMode: RoundingMode.floor }),
-                BigNum.valueOf(6).sqrt({ roundingMode: RoundingMode.ceil }),
-            ];
-        } 1`] = `
+			// Math.sqrt(6)
+			return [
+				BigNum.valueOf(6).sqrt({ roundingMode: RoundingMode.trunc }),
+				BigNum.valueOf(6).sqrt({ roundingMode: RoundingMode.round }),
+				BigNum.valueOf(6).sqrt({ roundingMode: RoundingMode.floor }),
+				BigNum.valueOf(6).sqrt({ roundingMode: RoundingMode.ceil })
+			];
+		} 1`] = `
 "[
   \\"2.4494897427831780981\\",
   \\"2.4494897427831780982\\",
@@ -158,14 +95,14 @@ exports[`standard tests () => {
 `;
 
 exports[`standard tests () => {
-            // Math.sqrt(7)
-            return [
-                BigNum.valueOf(7).sqrt({ roundingMode: RoundingMode.trunc }),
-                BigNum.valueOf(7).sqrt({ roundingMode: RoundingMode.round }),
-                BigNum.valueOf(7).sqrt({ roundingMode: RoundingMode.floor }),
-                BigNum.valueOf(7).sqrt({ roundingMode: RoundingMode.ceil }),
-            ];
-        } 1`] = `
+			// Math.sqrt(7)
+			return [
+				BigNum.valueOf(7).sqrt({ roundingMode: RoundingMode.trunc }),
+				BigNum.valueOf(7).sqrt({ roundingMode: RoundingMode.round }),
+				BigNum.valueOf(7).sqrt({ roundingMode: RoundingMode.floor }),
+				BigNum.valueOf(7).sqrt({ roundingMode: RoundingMode.ceil })
+			];
+		} 1`] = `
 "[
   \\"2.6457513110645905905\\",
   \\"2.6457513110645905905\\",
@@ -175,67 +112,51 @@ exports[`standard tests () => {
 `;
 
 exports[`standard tests () => {
-            const v = BigNum.valueOf(123.456);
-            // Not same instance
-            return v === new BigNumBasic(v);
-        } 1`] = `"false"`;
+			const v = BigNum.valueOf(123.456);
+			// Not same instance
+			return v === new BigNumBasic(v);
+		} 1`] = `"false"`;
 
 exports[`standard tests () => {
-            const v = BigNum.valueOf(123.456);
-            // Same instance
-            return v === BigNum.valueOf(v);
-        } 1`] = `"true"`;
+			const v = BigNum.valueOf(123.456);
+			// Same instance
+			return v === BigNum.valueOf(v);
+		} 1`] = `"true"`;
 
 exports[`standard tests () => {
-            const v = BigNum.valueOf(123.456);
-            // Same instance
-            return v === new BigNum(v);
-        } 1`] = `"true"`;
+			const v = BigNum.valueOf(123.456);
+			// Same instance
+			return v === new BigNum(v);
+		} 1`] = `"true"`;
 
 exports[`standard tests () => {
-            const v = BigNumBasic.valueOf(123.456);
-            // Not same instance
-            return v === new BigNum(v);
-        } 1`] = `"false"`;
+			const v = BigNumBasic.valueOf(123.456);
+			// Not same instance
+			return v === new BigNum(v);
+		} 1`] = `"false"`;
 
 exports[`standard tests () => {
-            const v = BigNumBasic.valueOf(123.456);
-            // Same instance
-            return v === BigNumBasic.valueOf(v);
-        } 1`] = `"true"`;
+			const v = BigNumBasic.valueOf(123.456);
+			// Same instance
+			return v === BigNumBasic.valueOf(v);
+		} 1`] = `"true"`;
 
 exports[`standard tests () => {
-            const v = BigNumBasic.valueOf(123.456);
-            // Same instance
-            return v === new BigNumBasic(v);
-        } 1`] = `"true"`;
+			const v = BigNumBasic.valueOf(123.456);
+			// Same instance
+			return v === new BigNumBasic(v);
+		} 1`] = `"true"`;
 
 exports[`standard tests () => {
-            return [
-                // @ts-expect-error -- test
-                BigNum.valueOf(0.2).add(0.1) + 42, // eslint-disable-line @typescript-eslint/restrict-plus-operands -- test
-                // eslint-disable-next-line @typescript-eslint/restrict-plus-operands, prefer-template -- test
-                BigNum.valueOf(0.2).add(0.1) + "str",
-                -BigNum.valueOf(0.2).add(0.1),
-            ];
-        } 1`] = `
-"[
-  42.3,
-  \\"0.3str\\",
-  -0.3
-]"
-`;
-
-exports[`standard tests () => {
-            return [
-                BigNum.parse("+11111111.000110011001101", 2),
-                BigNum.parse("+377.06315", 8),
-                BigNum.parse("+ff.199a", 16),
-                BigNum.parse("+0.0001100110011001100110011001100110011001100110011001101", 2),
-                BigNum.parse("+0.0631463146314631464", 8),
-                BigNum.parse("+0.1999999999999a", 16),
-            ];
-        } 1`] = `
+			return [
+				BigNum.parse("+11111111.000110011001101", 2),
+				BigNum.parse("+377.06315", 8),
+				BigNum.parse("+ff.199a", 16),
+				BigNum.parse("+0.0001100110011001100110011001100110011001100110011001101", 2),
+				BigNum.parse("+0.0631463146314631464", 8),
+				BigNum.parse("+0.1999999999999a", 16)
+			];
+		} 1`] = `
 "[
   \\"255.100006103515625\\",
   \\"255.100006103515625\\",
@@ -247,15 +168,15 @@ exports[`standard tests () => {
 `;
 
 exports[`standard tests () => {
-            return [
-                BigNum.parse("-11111111.000110011001101", 2),
-                BigNum.parse("-377.06315", 8),
-                BigNum.parse("-ff.199a", 16),
-                BigNum.parse("-.0001100110011001100110011001100110011001100110011001101", 2),
-                BigNum.parse("-.0631463146314631464", 8),
-                BigNum.parse("-.1999999999999a", 16),
-            ];
-        } 1`] = `
+			return [
+				BigNum.parse("-11111111.000110011001101", 2),
+				BigNum.parse("-377.06315", 8),
+				BigNum.parse("-ff.199a", 16),
+				BigNum.parse("-.0001100110011001100110011001100110011001100110011001101", 2),
+				BigNum.parse("-.0631463146314631464", 8),
+				BigNum.parse("-.1999999999999a", 16)
+			];
+		} 1`] = `
 "[
   \\"-255.100006103515625\\",
   \\"-255.100006103515625\\",
@@ -267,12 +188,12 @@ exports[`standard tests () => {
 `;
 
 exports[`standard tests () => {
-            return [
-                BigNum.parse("0.0001100110011001100110011001100110011001100110011001101", 2),
-                BigNum.parse("0.0631463146314631464", 8),
-                BigNum.parse("0.1999999999999a", 16),
-            ];
-        } 1`] = `
+			return [
+				BigNum.parse("0.0001100110011001100110011001100110011001100110011001101", 2),
+				BigNum.parse("0.0631463146314631464", 8),
+				BigNum.parse("0.1999999999999a", 16)
+			];
+		} 1`] = `
 "[
   \\"0.1000000000000000055511151231257827021181583404541015625\\",
   \\"0.1000000000000000055511151231257827021181583404541015625\\",
@@ -281,16 +202,30 @@ exports[`standard tests () => {
 `;
 
 exports[`standard tests () => {
-            return [
-                BigNum.parse("11111111.000110011001101", 2),
-                BigNum.parse("377.06315", 8),
-                BigNum.parse("ff.199a", 16),
-            ];
-        } 1`] = `
+			return [
+				BigNum.parse("11111111.000110011001101", 2),
+				BigNum.parse("377.06315", 8),
+				BigNum.parse("ff.199a", 16)
+			];
+		} 1`] = `
 "[
   \\"255.100006103515625\\",
   \\"255.100006103515625\\",
   \\"255.100006103515625\\"
+]"
+`;
+
+exports[`standard tests () => {
+			return [
+				BigNum.valueOf(.2).add(.1) + 42,
+				BigNum.valueOf(.2).add(.1) + "str",
+				-BigNum.valueOf(.2).add(.1)
+			];
+		} 1`] = `
+"[
+  42.3,
+  \\"0.3str\\",
+  -0.3
 ]"
 `;
 
@@ -324,11 +259,83 @@ exports[`standard tests () => BigNum.valueOf("-.1").multiply(10).floor() 1`] = `
 
 exports[`standard tests () => BigNum.valueOf("-.1").multiply(10).round() 1`] = `"-1"`;
 
-exports[`standard tests () => BigNum.valueOf("2e2").divide(1000).add(0.1) 1`] = `"0.3"`;
+exports[`standard tests () => BigNum.valueOf("2e2").divide(1e3).add(.1) 1`] = `"0.3"`;
 
 exports[`standard tests () => BigNum.valueOf("6.758057543099835e+41") 1`] = `"\\"675805754309983500000000000000000000000000\\""`;
 
 exports[`standard tests () => BigNum.valueOf("foo") 1`] = `"$NaN$"`;
+
+exports[`standard tests () => BigNum.valueOf(.001).compareTo(.001) 1`] = `"0"`;
+
+exports[`standard tests () => BigNum.valueOf(.001).compareTo(.002) 1`] = `"-1"`;
+
+exports[`standard tests () => BigNum.valueOf(.001).multiply(.001) 1`] = `"0.000001"`;
+
+exports[`standard tests () => BigNum.valueOf(.001).multiply(.002) 1`] = `"0.000002"`;
+
+exports[`standard tests () => BigNum.valueOf(.002).compareTo(.001) 1`] = `"1"`;
+
+exports[`standard tests () => BigNum.valueOf(.002).multiply(.001) 1`] = `"0.000002"`;
+
+exports[`standard tests () => BigNum.valueOf(.008).nthRoot(3) 1`] = `"0.2"`;
+
+exports[`standard tests () => BigNum.valueOf(.02).add(.1) 1`] = `"0.12"`;
+
+exports[`standard tests () => BigNum.valueOf(.02).subtract(.1) 1`] = `"-0.08"`;
+
+exports[`standard tests () => BigNum.valueOf(.064).nthRoot(3) 1`] = `"0.4"`;
+
+exports[`standard tests () => BigNum.valueOf(.0145).sqrt() 1`] = `"\\"0.1204159457879229548\\""`;
+
+exports[`standard tests () => BigNum.valueOf(.2).add(.01) 1`] = `"0.21"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).add(.1) 1`] = `"0.3"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).nthRoot(-2) 1`] = `"\\"2.23606797749978969641\\""`;
+
+exports[`standard tests () => BigNum.valueOf(.2).nthRoot(-3) 1`] = `"\\"1.70997594667669698935\\""`;
+
+exports[`standard tests () => BigNum.valueOf(.2).nthRoot(-4) 1`] = `"\\"1.49534878122122054191\\""`;
+
+exports[`standard tests () => BigNum.valueOf(.2).nthRoot(2) 1`] = `"\\"0.44721359549995793928\\""`;
+
+exports[`standard tests () => BigNum.valueOf(.2).nthRoot(3) 1`] = `"\\"0.5848035476425732131\\""`;
+
+exports[`standard tests () => BigNum.valueOf(.2).nthRoot(4) 1`] = `"\\"0.668740304976422024\\""`;
+
+exports[`standard tests () => BigNum.valueOf(.2).nthRoot(BigNum.valueOf(.2).add(3.8)) 1`] = `"\\"0.668740304976422024\\""`;
+
+exports[`standard tests () => BigNum.valueOf(.2).pow(-2) 1`] = `"25"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).pow(-3) 1`] = `"125"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).pow(-4) 1`] = `"625"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).pow(2) 1`] = `"0.04"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).pow(3) 1`] = `"0.008"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).pow(4) 1`] = `"0.0016"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).pow(BigNum.valueOf(.2).add(3.8)) 1`] = `"0.0016"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).scaleByPowerOfTen(2) 1`] = `"20"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).scaleByPowerOfTen(3) 1`] = `"200"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).scaleByPowerOfTen(4) 1`] = `"2000"`;
+
+exports[`standard tests () => BigNum.valueOf(.2).subtract(.01) 1`] = `"0.19"`;
+
+exports[`standard tests () => BigNum.valueOf(.3).subtract(.1) 1`] = `"0.2"`;
+
+exports[`standard tests () => BigNum.valueOf(.125).nthRoot(3) 1`] = `"0.5"`;
+
+exports[`standard tests () => BigNum.valueOf(.5625).sqrt() 1`] = `"0.75"`;
+
+exports[`standard tests () => BigNum.valueOf(-.001).divide(.003) 1`] = `"\\"-0.33333333333333333333\\""`;
+
+exports[`standard tests () => BigNum.valueOf(-.001).divide(-.003) 1`] = `"\\"0.33333333333333333333\\""`;
 
 exports[`standard tests () => BigNum.valueOf(-0).ceil() 1`] = `"0"`;
 
@@ -337,10 +344,6 @@ exports[`standard tests () => BigNum.valueOf(-0).floor() 1`] = `"0"`;
 exports[`standard tests () => BigNum.valueOf(-0).round() 1`] = `"0"`;
 
 exports[`standard tests () => BigNum.valueOf(-0).trunc() 1`] = `"0"`;
-
-exports[`standard tests () => BigNum.valueOf(-0.001).divide(-0.003) 1`] = `"\\"0.33333333333333333333\\""`;
-
-exports[`standard tests () => BigNum.valueOf(-0.001).divide(0.003) 1`] = `"\\"-0.33333333333333333333\\""`;
 
 exports[`standard tests () => BigNum.valueOf(-1).abs() 1`] = `"1"`;
 
@@ -386,7 +389,11 @@ exports[`standard tests () => BigNum.valueOf(-1.501).round() 1`] = `"-2"`;
 
 exports[`standard tests () => BigNum.valueOf(-1.501).trunc() 1`] = `"-1"`;
 
-exports[`standard tests () => BigNum.valueOf(-2.944).modulo(-0.128) 1`] = `"0"`;
+exports[`standard tests () => BigNum.valueOf(-2).nthRoot(2) 1`] = `"$NaN$"`;
+
+exports[`standard tests () => BigNum.valueOf(-2).sqrt() 1`] = `"$NaN$"`;
+
+exports[`standard tests () => BigNum.valueOf(-2.944).modulo(-.128) 1`] = `"0"`;
 
 exports[`standard tests () => BigNum.valueOf(-3).add(-Infinity) 1`] = `"$-Infinity$"`;
 
@@ -534,89 +541,29 @@ exports[`standard tests () => BigNum.valueOf(0).sqrt() 1`] = `"0"`;
 
 exports[`standard tests () => BigNum.valueOf(0).trunc() 1`] = `"0"`;
 
-exports[`standard tests () => BigNum.valueOf(0.000009).sqrt() 1`] = `"0.003"`;
-
-exports[`standard tests () => BigNum.valueOf(0.00001024).sqrt() 1`] = `"0.0032"`;
-
-exports[`standard tests () => BigNum.valueOf(0.001).compareTo(0.001) 1`] = `"0"`;
-
-exports[`standard tests () => BigNum.valueOf(0.001).compareTo(0.002) 1`] = `"-1"`;
-
-exports[`standard tests () => BigNum.valueOf(0.001).multiply(0.001) 1`] = `"0.000001"`;
-
-exports[`standard tests () => BigNum.valueOf(0.001).multiply(0.002) 1`] = `"0.000002"`;
-
-exports[`standard tests () => BigNum.valueOf(0.002).compareTo(0.001) 1`] = `"1"`;
-
-exports[`standard tests () => BigNum.valueOf(0.002).multiply(0.001) 1`] = `"0.000002"`;
-
-exports[`standard tests () => BigNum.valueOf(0.008).nthRoot(3) 1`] = `"0.2"`;
-
-exports[`standard tests () => BigNum.valueOf(0.02).add(0.1) 1`] = `"0.12"`;
-
-exports[`standard tests () => BigNum.valueOf(0.02).subtract(0.1) 1`] = `"-0.08"`;
-
-exports[`standard tests () => BigNum.valueOf(0.064).nthRoot(3) 1`] = `"0.4"`;
-
-exports[`standard tests () => BigNum.valueOf(0.0145).sqrt() 1`] = `"\\"0.1204159457879229548\\""`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).add(0.01) 1`] = `"0.21"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).add(0.1) 1`] = `"0.3"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).nthRoot(-2) 1`] = `"\\"2.23606797749978969641\\""`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).nthRoot(-3) 1`] = `"\\"1.70997594667669698935\\""`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).nthRoot(-4) 1`] = `"\\"1.49534878122122054191\\""`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).nthRoot(2) 1`] = `"\\"0.44721359549995793928\\""`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).nthRoot(3) 1`] = `"\\"0.5848035476425732131\\""`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).nthRoot(4) 1`] = `"\\"0.668740304976422024\\""`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).nthRoot(BigNum.valueOf(0.2).add(3.8)) 1`] = `"\\"0.668740304976422024\\""`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).pow(-2) 1`] = `"25"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).pow(-3) 1`] = `"125"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).pow(-4) 1`] = `"625"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).pow(2) 1`] = `"0.04"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).pow(3) 1`] = `"0.008"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).pow(4) 1`] = `"0.0016"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).pow(BigNum.valueOf(0.2).add(3.8)) 1`] = `"0.0016"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).scaleByPowerOfTen(2) 1`] = `"20"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).scaleByPowerOfTen(3) 1`] = `"200"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).scaleByPowerOfTen(4) 1`] = `"2000"`;
-
-exports[`standard tests () => BigNum.valueOf(0.2).subtract(0.01) 1`] = `"0.19"`;
-
-exports[`standard tests () => BigNum.valueOf(0.3).subtract(0.1) 1`] = `"0.2"`;
-
-exports[`standard tests () => BigNum.valueOf(0.125).nthRoot(3) 1`] = `"0.5"`;
-
-exports[`standard tests () => BigNum.valueOf(0.5625).sqrt() 1`] = `"0.75"`;
-
 exports[`standard tests () => BigNum.valueOf(1).abs() 1`] = `"1"`;
 
 exports[`standard tests () => BigNum.valueOf(1).ceil() 1`] = `"1"`;
 
 exports[`standard tests () => BigNum.valueOf(1).divide(3) 1`] = `"\\"0.33333333333333333333\\""`;
 
+exports[`standard tests () => BigNum.valueOf(1).divide(3).add(BigNum.valueOf(1).divide(3)).add(1).multiply(3) 1`] = `"5"`;
+
+exports[`standard tests () => BigNum.valueOf(1).divide(3).add(BigNum.valueOf(1).divide(3)).subtract(1).multiply(3) 1`] = `"-1"`;
+
+exports[`standard tests () => BigNum.valueOf(1).divide(3).divide(2).multiply(BigNum.valueOf(1).divide(3).divide(2)).multiply(9).multiply(4) 1`] = `"1"`;
+
+exports[`standard tests () => BigNum.valueOf(1).divide(3).divide(BigNum.valueOf(1).divide(3).divide(2)).multiply(9).multiply(4) 1`] = `"72"`;
+
 exports[`standard tests () => BigNum.valueOf(1).divide(3).multiply(3) 1`] = `"1"`;
+
+exports[`standard tests () => BigNum.valueOf(1).divide(3).multiply(BigNum.valueOf(1).divide(3)).multiply(9) 1`] = `"1"`;
 
 exports[`standard tests () => BigNum.valueOf(1).divide(3).toJSON() 1`] = `"\\"0.33333333333333333333\\""`;
 
 exports[`standard tests () => BigNum.valueOf(1).divide(BigNum.valueOf(1).divide(3)) 1`] = `"3"`;
+
+exports[`standard tests () => BigNum.valueOf(1).divide(BigNum.valueOf(1).divide(3).divide(2)).multiply(9).multiply(4) 1`] = `"216"`;
 
 exports[`standard tests () => BigNum.valueOf(1).floor() 1`] = `"1"`;
 
@@ -666,7 +613,9 @@ exports[`standard tests () => BigNum.valueOf(1.501).sqrt() 1`] = `"\\"1.22515305
 
 exports[`standard tests () => BigNum.valueOf(1.501).trunc() 1`] = `"1"`;
 
-exports[`standard tests () => BigNum.valueOf(2).multiply(0.1).add(0.1) 1`] = `"0.3"`;
+exports[`standard tests () => BigNum.valueOf(1e3).nthRoot(3) 1`] = `"10"`;
+
+exports[`standard tests () => BigNum.valueOf(2).multiply(.1).add(.1) 1`] = `"0.3"`;
 
 exports[`standard tests () => BigNum.valueOf(2).nthRoot(-2) 1`] = `"\\"0.7071067811865475244\\""`;
 
@@ -681,6 +630,8 @@ exports[`standard tests () => BigNum.valueOf(2).nthRoot(2) 1`] = `"\\"1.41421356
 exports[`standard tests () => BigNum.valueOf(2).nthRoot(3) 1`] = `"\\"1.2599210498948731647\\""`;
 
 exports[`standard tests () => BigNum.valueOf(2).nthRoot(4) 1`] = `"\\"1.1892071150027210667\\""`;
+
+exports[`standard tests () => BigNum.valueOf(2).nthRoot(BigNum.valueOf(1).divide(3)) 1`] = `"8"`;
 
 exports[`standard tests () => BigNum.valueOf(2).nthRoot(Infinity) 1`] = `"1"`;
 
@@ -724,6 +675,8 @@ exports[`standard tests () => BigNum.valueOf(2).scaleByPowerOfTen(4) 1`] = `"200
 
 exports[`standard tests () => BigNum.valueOf(2).sqrt() 1`] = `"\\"1.4142135623730950488\\""`;
 
+exports[`standard tests () => BigNum.valueOf(2).sqrt({ roundingMode: RoundingMode.round }).pow(2) 1`] = `"\\"1.99999999999999999999522356663907438144\\""`;
+
 exports[`standard tests () => BigNum.valueOf(2.3).divide(1.1) 1`] = `"\\"2.09090909090909090909\\""`;
 
 exports[`standard tests () => BigNum.valueOf(2.25).sqrt() 1`] = `"1.5"`;
@@ -758,11 +711,11 @@ exports[`standard tests () => BigNum.valueOf(3).multiply(Infinity) 1`] = `"$Infi
 
 exports[`standard tests () => BigNum.valueOf(3).multiply(NaN) 1`] = `"$NaN$"`;
 
-exports[`standard tests () => BigNum.valueOf(3).nthRoot(-0.25) 1`] = `"\\"0.012345679012345679012\\""`;
+exports[`standard tests () => BigNum.valueOf(3).nthRoot(.25) 1`] = `"81"`;
+
+exports[`standard tests () => BigNum.valueOf(3).nthRoot(-.25) 1`] = `"\\"0.012345679012345679012\\""`;
 
 exports[`standard tests () => BigNum.valueOf(3).nthRoot(-2.25) 1`] = `"\\"0.6136858490329160351\\""`;
-
-exports[`standard tests () => BigNum.valueOf(3).nthRoot(0.25) 1`] = `"81"`;
 
 exports[`standard tests () => BigNum.valueOf(3).nthRoot(2.25) 1`] = `"\\"1.6294982222188463389333008024474237364641187938089473904969509426245851708176\\""`;
 
@@ -790,8 +743,6 @@ exports[`standard tests () => BigNum.valueOf(5).sqrt() 1`] = `"\\"2.236067977499
 
 exports[`standard tests () => BigNum.valueOf(6).sqrt() 1`] = `"\\"2.4494897427831780981\\""`;
 
-exports[`standard tests () => BigNum.valueOf(6.758057543099835e41) 1`] = `"\\"675805754309983500000000000000000000000000\\""`;
-
 exports[`standard tests () => BigNum.valueOf(7).sqrt() 1`] = `"\\"2.6457513110645905905\\""`;
 
 exports[`standard tests () => BigNum.valueOf(8).nthRoot(3) 1`] = `"2"`;
@@ -799,6 +750,8 @@ exports[`standard tests () => BigNum.valueOf(8).nthRoot(3) 1`] = `"2"`;
 exports[`standard tests () => BigNum.valueOf(8).sqrt() 1`] = `"\\"2.8284271247461900976\\""`;
 
 exports[`standard tests () => BigNum.valueOf(9).sqrt() 1`] = `"3"`;
+
+exports[`standard tests () => BigNum.valueOf(9e-6).sqrt() 1`] = `"0.003"`;
 
 exports[`standard tests () => BigNum.valueOf(10).modulo(3) 1`] = `"1"`;
 
@@ -814,13 +767,15 @@ exports[`standard tests () => BigNum.valueOf(123.456).isNaN() 1`] = `"false"`;
 
 exports[`standard tests () => BigNum.valueOf(123.456).toJSON() 1`] = `"123.456"`;
 
-exports[`standard tests () => BigNum.valueOf(200).divide(100).add(0.1) 1`] = `"2.1"`;
+exports[`standard tests () => BigNum.valueOf(200).divide(100).add(.1) 1`] = `"2.1"`;
 
 exports[`standard tests () => BigNum.valueOf(512).nthRoot(3) 1`] = `"8"`;
 
-exports[`standard tests () => BigNum.valueOf(1000).nthRoot(3) 1`] = `"10"`;
+exports[`standard tests () => BigNum.valueOf(1024e-8).sqrt() 1`] = `"0.0032"`;
 
 exports[`standard tests () => BigNum.valueOf(271441).sqrt() 1`] = `"521"`;
+
+exports[`standard tests () => BigNum.valueOf(6758057543099835e26) 1`] = `"\\"675805754309983500000000000000000000000000\\""`;
 
 exports[`standard tests () => BigNum.valueOf(Infinity).abs() 1`] = `"$Infinity$"`;
 

--- a/packages/template-compiler/package.json
+++ b/packages/template-compiler/package.json
@@ -22,11 +22,11 @@
     "build": "npm run bundle",
     "bundle": "tsdown",
     "clean": "rimraf .nyc_output lib coverage",
-    "test": "mocha --loader=ts-node/esm \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
+    "test": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
     "cover": "c8 --reporter=lcov npm run test",
-    "debug": "mocha --loader=ts-node/esm/transpile-only \"tests/src/**/*.mts\" --reporter dot",
+    "debug": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot",
     "type-check": "tsc --noEmit",
-    "update-snap": "mocha --loader=ts-node/esm \"tests/src/**/*.mts\" --reporter dot --update"
+    "update-snap": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --update"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/template-light/package.json
+++ b/packages/template-light/package.json
@@ -27,11 +27,11 @@
     "build": "npm run bundle",
     "bundle": "tsdown",
     "clean": "rimraf .nyc_output lib coverage",
-    "test": "mocha --loader=ts-node/esm \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
+    "test": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
     "cover": "c8 --reporter=lcov npm run test",
-    "debug": "mocha --loader=ts-node/esm/transpile-only \"tests/src/**/*.mts\" --reporter dot",
+    "debug": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot",
     "type-check": "tsc --noEmit",
-    "update-snap": "mocha --loader=ts-node/esm \"tests/src/**/*.mts\" --reporter dot --update",
+    "update-snap": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --update",
     "update-readme-size": "node ./scripts/gzip-size.mjs"
   },
   "publishConfig": {

--- a/packages/template-light/tests/src/index.mts
+++ b/packages/template-light/tests/src/index.mts
@@ -1,5 +1,9 @@
 import { f } from "../../src/index.mjs";
 import * as snap from "@ota-meshi/test-snapshot";
+import { copyFile, mkdir, mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 describe("standard tests", () => {
   for (const t of [
@@ -125,8 +129,6 @@ type WeakMapSpyInstance = {
   setKeys: object[];
 };
 
-let templateLightImportVersion = 0;
-
 async function withWeakMapSpy(
   run: (instances: WeakMapSpyInstance[]) => Promise<void>,
 ) {
@@ -157,9 +159,28 @@ async function withWeakMapSpy(
 }
 
 async function importFreshTemplateLight() {
-  const url = new URL("../../src/index.mjs", import.meta.url);
-  url.searchParams.set("cache-test", String(templateLightImportVersion++));
-  return import(url.href);
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "bignum-template-light-"),
+  );
+  const sourceDirectory = fileURLToPath(new URL("../../src/", import.meta.url));
+  const copiedSourceDirectory = join(temporaryDirectory, "src");
+  await mkdir(copiedSourceDirectory);
+
+  for (const entry of await readdir(sourceDirectory)) {
+    if (!entry.endsWith(".mts")) continue;
+    await copyFile(
+      join(sourceDirectory, entry),
+      join(copiedSourceDirectory, entry),
+    );
+  }
+
+  try {
+    return await import(
+      pathToFileURL(join(copiedSourceDirectory, "index.mts")).href
+    );
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
 }
 
 function getTemplateCache(instances: WeakMapSpyInstance[]) {

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -27,11 +27,11 @@
     "build": "npm run bundle",
     "bundle": "tsdown",
     "clean": "rimraf .nyc_output lib coverage",
-    "test": "mocha --loader=ts-node/esm \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
+    "test": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --timeout 60000",
     "cover": "c8 --reporter=lcov npm run test",
-    "debug": "mocha --loader=ts-node/esm/transpile-only \"tests/src/**/*.mts\" --reporter dot",
+    "debug": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot",
     "type-check": "tsc --noEmit",
-    "update-snap": "mocha --loader=ts-node/esm/transpile-only \"tests/src/**/*.mts\" --reporter dot --update",
+    "update-snap": "node --import @oxc-node/core/register ../../node_modules/mocha/bin/mocha.js \"tests/src/**/*.mts\" --reporter dot --update",
     "update-readme-size": "node ./scripts/gzip-size.mjs"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- replace `ts-node` with `@oxc-node/core` for TypeScript runtime scripts
- switch workspace test/debug/update-snap commands to `node --import @oxc-node/core/register`
- adjust the `@bignum/template-light` compile-cache test to avoid query-string imports that `@oxc-node/core` does not handle

## Verification
- passed: `packages/template-light` tests with the new `@oxc-node/core` runner
- ran: root `npm test`

## Notes
- added a changeset for the affected published packages
- this change was prepared with Codex