### PR TITLE
Fix release workflow inputs for changesets/action v2

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -39,8 +39,8 @@ jobs:
         uses: changesets/action@v2.0.0
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: npm run release
-          commit: "chore: release"
-          title: "chore: release"
+          publish-script: npm run release
+          commit-message: "chore: release"
+          pr-title: "chore: release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`changesets/action@v2` rejects the legacy `publish`, `commit`, and `title` inputs, causing the Release workflow triggered by #169 to fail before it can create or update a release pull request.

Use the renamed v2 inputs (`publish-script`, `commit-message`, and `pr-title`) while preserving the existing release command and generated commit and pull request text.
